### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,21 +2,19 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Java CI with Maven
-
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
-
+    branches:
+      - main
 jobs:
   build:
     env:
       AWS_DEFAULT_REGION: us-east-1
       AWS_REGION: us-east-1
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -40,6 +38,3 @@ jobs:
           cd ..
           cd ./statemachine
           mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B clean verify
-      - name: Failure diff
-        if: ${{ failure() }}
-        run: git diff


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds GitHub actions CI. Runs `mvn clean verify` for each resource. 

Based on this [PR](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/pull/54/files). Given the current naming convention of our resources, we cannot iterate through the subdirectories looking for directories prefixed with `aws-*`. We should rename the resources in a future PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
