### PR TITLE
Fix type metrics

### DIFF
--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/MetricsRecorder.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/MetricsRecorder.java
@@ -87,14 +87,11 @@ public class MetricsRecorder {
             setAreDefinitionSubstitutionsProvided(true);
         }
 
-        if (model.getStateMachineType() != null) {
-            if (model.getStateMachineType().equals(Constants.STANDARD_STATE_MACHINE_TYPE)) {
-                setStateMachineStandardType(true);
-            }
-
-            if (model.getStateMachineType().equals(Constants.EXPRESS_STATE_MACHINE_TYPE)) {
-                setStateMachineExpressType(true);
-            }
+        // State Machine type is STANDARD by default
+        if (model.getStateMachineType() == null || model.getStateMachineType().equals(Constants.STANDARD_STATE_MACHINE_TYPE)) {
+            setStateMachineStandardType(true);
+        } else if (model.getStateMachineType().equals(Constants.EXPRESS_STATE_MACHINE_TYPE)) {
+            setStateMachineExpressType(true);
         }
 
         if (model.getLoggingConfiguration() != null) {

--- a/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CreateHandlerTest.java
+++ b/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CreateHandlerTest.java
@@ -525,6 +525,26 @@ public class CreateHandlerTest extends HandlerTestBase {
     }
 
     @Test
+    public void testLogsStateMachineType_whenTypeIsNull() {
+        request.getDesiredResourceState().setDefinitionString("{}");
+        request.getDesiredResourceState().setStateMachineType(null);
+
+        CreateStateMachineResult createStateMachineResult = new CreateStateMachineResult();
+        createStateMachineResult.setStateMachineArn(STATE_MACHINE_ARN);
+
+        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(CreateStateMachineRequest.class), Mockito.any(Function.class))).thenReturn(createStateMachineResult);
+
+        ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        Mockito.verify(logger, Mockito.times(2)).log(argumentCaptor.capture());
+        List<String> loggedStrings = argumentCaptor.getAllValues();
+        String metricsString = loggedStrings.get(loggedStrings.size() - 1);
+
+        assertThat(metricsString).contains(STATE_MACHINE_STANDARD_TYPE.loggingKey);
+    }
+
+    @Test
     public void testLogsTracing_whenTracingIsEnabledTrue() {
         request.getDesiredResourceState().setDefinitionString("{}");
         request.getDesiredResourceState().setTracingConfiguration(createTracingConfiguration(TRACING_CONFIGURATION_ENABLED));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
State Machine type defaults to Standard if not provided. Currently metrics are only collected if the type is not null. After this change, null type will be logged as a Standard state machine. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
