### PR TITLE
Update contract test dependencies to have updated dependency stack ou…

### DIFF
--- a/statemachine/inputs/inputs_1_create.json
+++ b/statemachine/inputs/inputs_1_create.json
@@ -1,6 +1,6 @@
 {
-  "StateMachineName": "{{ContractTestStateMachineName}}",
-  "RoleArn": "{{ContractTestStateMachineRole}}",
+  "StateMachineName": "{{TestStateMachineName}}",
+  "RoleArn": "{{TestStateMachineRole}}",
   "StateMachineType": "STANDARD",
   "Definition": {
     "StartAt": "Hello",

--- a/statemachine/inputs/inputs_1_invalid.json
+++ b/statemachine/inputs/inputs_1_invalid.json
@@ -1,6 +1,6 @@
 {
-  "StateMachineName": "{{ContractTestInvalidStateMachineName}}",
-  "RoleArn": "{{ContractTestStateMachineRole}}",
+  "StateMachineName": "{{TestInvalidStateMachineName}}",
+  "RoleArn": "{{TestStateMachineRole}}",
   "StateMachineType": "STANDARD",
   "Definition": {
     "StartAt": "Hello",

--- a/statemachine/inputs/inputs_1_update.json
+++ b/statemachine/inputs/inputs_1_update.json
@@ -1,6 +1,6 @@
 {
-  "StateMachineName": "{{ContractTestStateMachineName}}",
-  "RoleArn": "{{ContractTestStateMachineRole}}",
+  "StateMachineName": "{{TestStateMachineName}}",
+  "RoleArn": "{{TestStateMachineRole}}",
   "StateMachineType": "STANDARD",
   "Definition": {
     "StartAt": "Hello",

--- a/statemachine/inputs/inputs_2_create.json
+++ b/statemachine/inputs/inputs_2_create.json
@@ -1,6 +1,6 @@
 {
-  "StateMachineName": "{{ContractTestStateMachineName}}",
-  "RoleArn": "{{ContractTestStateMachineRole}}",
+  "StateMachineName": "{{TestStateMachineName}}",
+  "RoleArn": "{{TestStateMachineRole}}",
   "StateMachineType": "EXPRESS",
   "Definition": {
     "StartAt": "Hello",

--- a/statemachine/inputs/inputs_2_invalid.json
+++ b/statemachine/inputs/inputs_2_invalid.json
@@ -1,6 +1,6 @@
 {
-  "StateMachineName": "{{ContractTestInvalidStateMachineName}}",
-  "RoleArn": "{{ContractTestStateMachineRole}}",
+  "StateMachineName": "{{TestInvalidStateMachineName}}",
+  "RoleArn": "{{TestStateMachineRole}}",
   "StateMachineType": "EXPRESS",
   "Definition": {
     "StartAt": "Hello",

--- a/statemachine/inputs/inputs_2_update.json
+++ b/statemachine/inputs/inputs_2_update.json
@@ -1,6 +1,6 @@
 {
-  "StateMachineName": "{{ContractTestStateMachineName}}",
-  "RoleArn": "{{ContractTestStateMachineRole}}",
+  "StateMachineName": "{{TestStateMachineName}}",
+  "RoleArn": "{{TestStateMachineRole}}",
   "StateMachineType": "EXPRESS",
   "Definition": {
     "StartAt": "Hello",


### PR DESCRIPTION
…tput reference

*Description of changes:*
The dependency stack outputs have been renamed. This change updates the dependency stack references in the input files for the state machine resource's contract tests to have the updated value. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
