### PR TITLE
fix: Broken package build with cloudformation-cli-java-plugin 2.0.6

### DIFF
--- a/activity/pom.xml
+++ b/activity/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.6</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/statemachine/pom.xml
+++ b/statemachine/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.6</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>


### PR DESCRIPTION
*Description of changes:*
With the release of cloudformation-cli-java-plugin `2.0.6`, the package build was failing due to package dependencies not being up to date. This change updates the `aws-cloudformation-rpdk-java-plugin` dependency to `2.0.6` for both activity and state machine resources. 

Tested with a fresh virtual environment with cloudformation-cli-java-plugin 2.0.6 that both resources succeed when running `mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B clean verify`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
