### PR TITLE
fix: update DeleteHandler behaviour to succeed if resource does not exist

### DIFF
--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DeleteHandler.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DeleteHandler.java
@@ -33,7 +33,9 @@ public class DeleteHandler extends ResourceHandler {
 
             if (!currentContext.isDeletionStarted()) {
                 if (!doesStateMachineExist(model, proxy, sfnClient)) {
-                    throw getStateMachineDoesNotExistException();
+                    return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                            .status(OperationStatus.SUCCESS)
+                            .build();
                 }
 
                 deleteStateMachine(model, proxy, sfnClient);

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ResourceHandler.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ResourceHandler.java
@@ -85,7 +85,7 @@ public abstract class ResourceHandler extends BaseHandler<CallbackContext> {
         }
     }
 
-    protected AmazonServiceException getStateMachineDoesNotExistException() {
+    private AmazonServiceException getStateMachineDoesNotExistException() {
         AmazonServiceException exception = new AmazonServiceException(Constants.STATE_MACHINE_DOES_NOT_EXIST_ERROR_MESSAGE);
         exception.setStatusCode(400);
         exception.setErrorCode(Constants.STATE_MACHINE_DOES_NOT_EXIST_ERROR_CODE);

--- a/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DeleteHandlerTest.java
+++ b/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DeleteHandlerTest.java
@@ -149,9 +149,7 @@ public class DeleteHandlerTest extends HandlerTestBase {
         final ProgressEvent<ResourceModel, CallbackContext> response
                 = handler.handleRequest(proxy, request, null, logger);
 
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
-        assertThat(response.getMessage()).contains(Constants.STATE_MACHINE_DOES_NOT_EXIST_ERROR_MESSAGE);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
Updates the DeleteHandler behaviour to be consistent with DeleteStateMachine API, which returns successfully even if the resource does not exist. Also updates the related unit test and changes the visibility of `getStateMachineDoesNotExistException` to be private since it is no longer invoked outside of ResourceHandler.java

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
