### PR TITLE
Update permissions

### DIFF
--- a/statemachine/aws-stepfunctions-statemachine.json
+++ b/statemachine/aws-stepfunctions-statemachine.json
@@ -205,7 +205,8 @@
     },
     "delete": {
       "permissions": [
-        "states:DeleteStateMachine"
+        "states:DeleteStateMachine",
+        "states:DescribeStateMachine"
       ]
     }
   }

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DeleteHandler.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DeleteHandler.java
@@ -33,9 +33,7 @@ public class DeleteHandler extends ResourceHandler {
 
             if (!currentContext.isDeletionStarted()) {
                 if (!doesStateMachineExist(model, proxy, sfnClient)) {
-                    return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                            .status(OperationStatus.SUCCESS)
-                            .build();
+                    throw getStateMachineDoesNotExistException();
                 }
 
                 deleteStateMachine(model, proxy, sfnClient);

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ResourceHandler.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ResourceHandler.java
@@ -85,7 +85,7 @@ public abstract class ResourceHandler extends BaseHandler<CallbackContext> {
         }
     }
 
-    private AmazonServiceException getStateMachineDoesNotExistException() {
+    protected AmazonServiceException getStateMachineDoesNotExistException() {
         AmazonServiceException exception = new AmazonServiceException(Constants.STATE_MACHINE_DOES_NOT_EXIST_ERROR_MESSAGE);
         exception.setStatusCode(400);
         exception.setErrorCode(Constants.STATE_MACHINE_DOES_NOT_EXIST_ERROR_CODE);

--- a/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DeleteHandlerTest.java
+++ b/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DeleteHandlerTest.java
@@ -149,7 +149,9 @@ public class DeleteHandlerTest extends HandlerTestBase {
         final ProgressEvent<ResourceModel, CallbackContext> response
                 = handler.handleRequest(proxy, request, null, logger);
 
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
+        assertThat(response.getMessage()).contains(Constants.STATE_MACHINE_DOES_NOT_EXIST_ERROR_MESSAGE);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reverts the change updating DeleteHandler behaviour to return success if resource does not exist, as this breaks contract test for delete->delete. Verified that contract tests now pass.

Also updates permission list for DeleteHandler to reflect calling of DescribeStateMachine. We are looking into whether these permissions are currently captured in any public documentation, and if not, how they can be. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
