### PR TITLE
Update DefinitionSubstitutions to allow non-string types

### DIFF
--- a/statemachine/aws-stepfunctions-statemachine.json
+++ b/statemachine/aws-stepfunctions-statemachine.json
@@ -101,8 +101,11 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        ".*": {
+        "key": {
           "type": "string"
+        },
+        "value": {
+          "type": "object"
         }
       },
       "minProperties": 1

--- a/statemachine/aws-stepfunctions-statemachine.json
+++ b/statemachine/aws-stepfunctions-statemachine.json
@@ -107,7 +107,7 @@
               "type": "string"
             },
             {
-              "type": "number"
+              "type": "integer"
             },
             {
               "type": "boolean"

--- a/statemachine/aws-stepfunctions-statemachine.json
+++ b/statemachine/aws-stepfunctions-statemachine.json
@@ -101,11 +101,18 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "object"
+        ".*": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
         }
       },
       "minProperties": 1

--- a/statemachine/docs/definitionsubstitutions.md
+++ b/statemachine/docs/definitionsubstitutions.md
@@ -8,32 +8,22 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 <pre>
 {
-    "<a href="#key" title="key">key</a>" : <i>String</i>,
-    "<a href="#value" title="value">value</a>" : <i>Map</i>
+    "<a href="#.*" title=".*">.*</a>" : <i>String, Double, Boolean</i>
 }
 </pre>
 
 ### YAML
 
 <pre>
-<a href="#key" title="key">key</a>: <i>String</i>
-<a href="#value" title="value">value</a>: <i>Map</i>
+<a href="#.*" title=".*">.*</a>: <i>String, Double, Boolean</i>
 </pre>
 
 ## Properties
 
-#### key
+#### \.*
 
 _Required_: No
 
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### value
-
-_Required_: No
-
-_Type_: Map
+_Type_: String, Double, Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/statemachine/docs/definitionsubstitutions.md
+++ b/statemachine/docs/definitionsubstitutions.md
@@ -8,22 +8,32 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 <pre>
 {
-    "<a href="#.*" title=".*">.*</a>" : <i>String</i>
+    "<a href="#key" title="key">key</a>" : <i>String</i>,
+    "<a href="#value" title="value">value</a>" : <i>Map</i>
 }
 </pre>
 
 ### YAML
 
 <pre>
-<a href="#.*" title=".*">.*</a>: <i>String</i>
+<a href="#key" title="key">key</a>: <i>String</i>
+<a href="#value" title="value">value</a>: <i>Map</i>
 </pre>
 
 ## Properties
 
-#### \.*
+#### key
 
 _Required_: No
 
 _Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### value
+
+_Required_: No
+
+_Type_: Map
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/statemachine/docs/definitionsubstitutions.md
+++ b/statemachine/docs/definitionsubstitutions.md
@@ -8,14 +8,14 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 <pre>
 {
-    "<a href="#.*" title=".*">.*</a>" : <i>String, Double, Boolean</i>
+    "<a href="#.*" title=".*">.*</a>" : <i>String, Integer, Boolean</i>
 }
 </pre>
 
 ### YAML
 
 <pre>
-<a href="#.*" title=".*">.*</a>: <i>String, Double, Boolean</i>
+<a href="#.*" title=".*">.*</a>: <i>String, Integer, Boolean</i>
 </pre>
 
 ## Properties
@@ -24,6 +24,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 _Required_: No
 
-_Type_: String, Double, Boolean
+_Type_: String, Integer, Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/Constants.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/Constants.java
@@ -18,6 +18,7 @@ public class Constants {
     public static final String DEFINITION_INVALID_FORMAT_ERROR_MESSAGE = "Invalid StateMachine definition.";
     public static final String DEFINITION_MISSING_ERROR_MESSAGE = "Property validation failed. Required key [DefinitionS3Location], [DefinitionString] or [Definition] not found.";
     public static final String DEFINITION_REDUNDANT_ERROR_MESSAGE = "Property validation failed. Please use one of [DefinitionS3Location], [DefinitionString] or [Definition].";
+    public static final String DEFINITION_SUBSTITUTION_INVALID_TYPE_ERROR_MESSAGE = "Invalid definition substitution type. Input should be either String, Integer, or Boolean";
     public static final String STATE_MACHINE_DOES_NOT_EXIST_ERROR_CODE = "StateMachineDoesNotExist";
     public static final String STATE_MACHINE_DOES_NOT_EXIST_ERROR_MESSAGE = "State machine does not exist";
     public static final Set<String> INVALID_REQUESTS_ERROR_CODES = Sets.newHashSet("InvalidArn", "InvalidDefinition", "InvalidLoggingConfiguration", "InvalidName");

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DefinitionProcessor.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DefinitionProcessor.java
@@ -151,6 +151,9 @@ public class DefinitionProcessor {
         List<String> searchList = new ArrayList<>();
         List<String> replacementList = new ArrayList<>();
         for (Map.Entry<String, Object> e : resourceMappings.entrySet()) {
+            if (!(e.getValue() instanceof String) && !(e.getValue() instanceof Integer) && !(e.getValue() instanceof Boolean)) {
+                throw new TerminalException(Constants.DEFINITION_SUBSTITUTION_INVALID_TYPE_ERROR_MESSAGE);
+            }
             searchList.add("${" + e.getKey() + "}");
             replacementList.add(e.getValue().toString());
         }

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DefinitionProcessor.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DefinitionProcessor.java
@@ -113,7 +113,7 @@ public class DefinitionProcessor {
             throw new CfnInternalFailureException(e);
         }
 
-        //DefinitionSubstitution before validating JSON or YAML format
+        // DefinitionSubstitution before validating JSON or YAML format
         if (model.getDefinitionSubstitutions() != null) {
             definition = transformDefinition(definition, model.getDefinitionSubstitutions());
         }

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DefinitionProcessor.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/DefinitionProcessor.java
@@ -79,8 +79,8 @@ public class DefinitionProcessor {
      * @param metricsRecorder The MetricsRecorder object used for collecting anonymous property usage metrics
      */
     public static void processDefinition(final AmazonWebServicesClientProxy proxy, final ResourceModel model, final MetricsRecorder metricsRecorder) {
-        String definition = "";
-        if(model.getDefinitionString() != null){
+        String definition;
+        if(model.getDefinitionString() != null) {
             definition = model.getDefinitionString();
         }
         else{
@@ -147,12 +147,12 @@ public class DefinitionProcessor {
         }
     }
 
-    private static String transformDefinition(final String definitionString, final Map<String, String> resourceMappings) {
+    private static String transformDefinition(final String definitionString, final Map<String, Object> resourceMappings) {
         List<String> searchList = new ArrayList<>();
         List<String> replacementList = new ArrayList<>();
-        for (Map.Entry<String, String> e : resourceMappings.entrySet()) {
+        for (Map.Entry<String, Object> e : resourceMappings.entrySet()) {
             searchList.add("${" + e.getKey() + "}");
-            replacementList.add(e.getValue());
+            replacementList.add(e.getValue().toString());
         }
         return StringUtils.replaceEachRepeatedly(definitionString, searchList.toArray(new String[0]), replacementList.toArray(new String[0]));
     }

--- a/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CreateHandlerTest.java
+++ b/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CreateHandlerTest.java
@@ -186,15 +186,20 @@ public class CreateHandlerTest extends HandlerTestBase {
         Map<String, Object> passState = new HashMap<>();
         passState.put("Next", "${lambdaStateName}");
 
+        Map<String, Object> timeoutSeconds = new HashMap<>();
+        passState.put("TimeoutSeconds", "${timeoutSeconds}");
+
         Map<String, Map<String, Object>> states = new HashMap<>();
         states.put("lambda_01", lambdaState);
         states.put("PassState", passState);
+        states.put("TimeoutSeconds", timeoutSeconds);
 
         definition.put("States", states);
 
         Map<String, String> substitutions = new HashMap<>();
         substitutions.put("lambdaArn01", "lambdaArn01");
         substitutions.put("lambdaStateName", "lambda_01");
+        substitutions.put("timeoutSeconds", "60");
 
         request.getDesiredResourceState().setDefinitionSubstitutions(substitutions);
         request.getDesiredResourceState().setDefinition(definition);

--- a/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CreateHandlerTest.java
+++ b/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CreateHandlerTest.java
@@ -142,12 +142,20 @@ public class CreateHandlerTest extends HandlerTestBase {
                 "        \"Lambda01\": \"${lambdaArn01}\"\n" +
                 "      }\n" +
                 "    }\n" +
+                "    \"number\": {\n" +
+                "      \"Resource\": ${number}\n" +
+                "    },\n" +
+                "    \"boolean\": {\n" +
+                "      \"Resource\": ${boolean}\n" +
+                "    },\n" +
                 "  }\n" +
                 "}";
 
         Map<String, String> substitutions = new HashMap<>();
         substitutions.put("lambdaArn01", "lambdaArn01");
         substitutions.put("lambdaArn02", "lambdaArn02");
+        substitutions.put("number", "5");
+        substitutions.put("boolean", "true");
 
         request.getDesiredResourceState().setDefinitionSubstitutions(substitutions);
         request.getDesiredResourceState().setDefinitionString(definition);
@@ -164,6 +172,8 @@ public class CreateHandlerTest extends HandlerTestBase {
 
         assertThat(!transformedDefinition.contains("${lambdaArn01}")).isTrue();
         assertThat(!transformedDefinition.contains("${lambdaArn02}")).isTrue();
+        assertThat(!transformedDefinition.contains("${number}")).isTrue();
+        assertThat(!transformedDefinition.contains("${boolean}")).isTrue();
     }
 
     @Test
@@ -253,6 +263,46 @@ public class CreateHandlerTest extends HandlerTestBase {
 
         S3Object s3Object = new S3Object();
         s3Object.setObjectContent(new StringInputStream("Comment: Hello World"));
+        GetObjectResult getObjectResult = new GetObjectResult(s3Object);
+
+        CreateStateMachineResult createStateMachineResult = new CreateStateMachineResult();
+        createStateMachineResult.setStateMachineArn(STATE_MACHINE_ARN);
+
+        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(), Mockito.any(Function.class))).thenReturn(getObjectResult, createStateMachineResult);
+
+        ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getResourceModel().getDefinitionString()).isEqualTo(formattedJson);
+    }
+
+    @Test
+    public void testNonStringDefinitionSubstitutionFromS3() throws Exception {
+        String formattedJson = "{\n" +
+                "  \"StartAt\" : \"DummyState\",\n" +
+                "  \"TimeoutSeconds\" : 60,\n" +
+                "  \"States\" : {\n" +
+                "    \"DummyState\" : {\n" +
+                "      \"Type\" : \"Pass\",\n" +
+                "      \"End\" : true\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        Map<String, String> substitutions = new HashMap<>();
+        substitutions.put("startState", "DummyState");
+        substitutions.put("type", "Pass");
+        substitutions.put("timeoutSeconds", "60");
+        substitutions.put("isEnd", "true");
+
+        request.getDesiredResourceState().setDefinitionSubstitutions(substitutions);
+        request.getDesiredResourceState().setDefinitionS3Location(new S3Location(DEFAULT_S3_BUCKET, DEFAULT_S3_KEY, DEFAULT_S3_OBJECT_VERSION));
+
+        S3Object s3Object = new S3Object();
+        String definitionInS3 = "StartAt: \"${startState}\"\nTimeoutSeconds: ${timeoutSeconds}\nStates:\n  DummyState:\n    Type: Pass\n    End: ${isEnd}\n  ";
+        s3Object.setObjectContent(new StringInputStream(definitionInS3));
         GetObjectResult getObjectResult = new GetObjectResult(s3Object);
 
         CreateStateMachineResult createStateMachineResult = new CreateStateMachineResult();

--- a/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CreateHandlerTest.java
+++ b/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CreateHandlerTest.java
@@ -151,11 +151,11 @@ public class CreateHandlerTest extends HandlerTestBase {
                 "  }\n" +
                 "}";
 
-        Map<String, String> substitutions = new HashMap<>();
+        Map<String, Object> substitutions = new HashMap<>();
         substitutions.put("lambdaArn01", "lambdaArn01");
         substitutions.put("lambdaArn02", "lambdaArn02");
-        substitutions.put("number", "5");
-        substitutions.put("boolean", "true");
+        substitutions.put("number", 5);
+        substitutions.put("boolean", true);
 
         request.getDesiredResourceState().setDefinitionSubstitutions(substitutions);
         request.getDesiredResourceState().setDefinitionString(definition);
@@ -196,10 +196,10 @@ public class CreateHandlerTest extends HandlerTestBase {
 
         definition.put("States", states);
 
-        Map<String, String> substitutions = new HashMap<>();
+        Map<String, Object> substitutions = new HashMap<>();
         substitutions.put("lambdaArn01", "lambdaArn01");
         substitutions.put("lambdaStateName", "lambda_01");
-        substitutions.put("timeoutSeconds", "60");
+        substitutions.put("timeoutSeconds", 60);
 
         request.getDesiredResourceState().setDefinitionSubstitutions(substitutions);
         request.getDesiredResourceState().setDefinition(definition);
@@ -296,11 +296,11 @@ public class CreateHandlerTest extends HandlerTestBase {
                 "  }\n" +
                 "}";
 
-        Map<String, String> substitutions = new HashMap<>();
+        Map<String, Object> substitutions = new HashMap<>();
         substitutions.put("startState", "DummyState");
         substitutions.put("type", "Pass");
-        substitutions.put("timeoutSeconds", "60");
-        substitutions.put("isEnd", "true");
+        substitutions.put("timeoutSeconds", 60);
+        substitutions.put("isEnd", true);
 
         request.getDesiredResourceState().setDefinitionSubstitutions(substitutions);
         request.getDesiredResourceState().setDefinitionS3Location(new S3Location(DEFAULT_S3_BUCKET, DEFAULT_S3_KEY, DEFAULT_S3_OBJECT_VERSION));
@@ -336,11 +336,11 @@ public class CreateHandlerTest extends HandlerTestBase {
                 "  }\n" +
                 "}";
 
-        Map<String, String> substitutions = new HashMap<>();
+        Map<String, Object> substitutions = new HashMap<>();
         substitutions.put("startState", "DummyState");
         substitutions.put("type", "Pass");
-        substitutions.put("timeoutSeconds", "60");
-        substitutions.put("isEnd", "true");
+        substitutions.put("timeoutSeconds", 60);
+        substitutions.put("isEnd", true);
 
         request.getDesiredResourceState().setDefinitionSubstitutions(substitutions);
         request.getDesiredResourceState().setDefinitionS3Location(new S3Location(DEFAULT_S3_BUCKET, DEFAULT_S3_KEY, DEFAULT_S3_OBJECT_VERSION));


### PR DESCRIPTION
# Allow non-string types in DefinitionSubsitutions for AWS::StepFunctions::StateMachine

## Github Issue
This PR addresses [Github issue #591](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/591)

## Description

The `DefinitionSubstitutions` property allows customers to specify the mappings for placeholder variables in their state machine definition at runtime. Currently this property only supports [string substitutions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-definitionsubstitutions). 
The changes in this PR enables customers to substitute non-string types (String, Integer, Boolean) as well. 
