### PR TITLE
fix: bump jackson-dataformat-yaml to fix build

### DIFF
--- a/statemachine/pom.xml
+++ b/statemachine/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.10.1</version>
+            <version>2.14.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Maven build was failing due to `java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/util/JacksonFeature`. Bumped `jackson-dataformat-yaml` to `2.14.2`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
