### PR TITLE
Update statemachine SFN client to retry on missing logging permissions

### DIFF
--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilder.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilder.java
@@ -50,7 +50,7 @@ public class ClientBuilder {
             return Constants.ACCESS_DENIED_ERROR_CODE.equals(exception.getErrorCode())
                     && (exception.getErrorMessage().contains(Constants.MANAGED_RULE_EXCEPTION_MESSAGE_SUBSTRING) ||
                     exception.getErrorMessage().contains(Constants.STS_AUTHORIZED_TO_ASSUME_MESSAGE_SUBSTRING) ||
-                    exception.getErrorMessage().contains(Constants.LOGGING_ACCESS_DENIED_SUBSTRING));
+                    exception.getErrorMessage().contains(Constants.LOGGING_ACCESS_DENIED_MESSAGE_SUBSTRING));
         }
 
     }

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilder.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilder.java
@@ -49,7 +49,8 @@ public class ClientBuilder {
         private boolean isRetriableException(AmazonServiceException exception) {
             return Constants.ACCESS_DENIED_ERROR_CODE.equals(exception.getErrorCode())
                     && (exception.getErrorMessage().contains(Constants.MANAGED_RULE_EXCEPTION_MESSAGE_SUBSTRING) ||
-                    exception.getErrorMessage().contains(Constants.STS_AUTHORIZED_TO_ASSUME_MESSAGE_SUBSTRING));
+                    exception.getErrorMessage().contains(Constants.STS_AUTHORIZED_TO_ASSUME_MESSAGE_SUBSTRING) ||
+                    exception.getErrorMessage().contains(Constants.LOGGING_ACCESS_DENIED_SUBSTRING));
         }
 
     }

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/Constants.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
     public static final String INTERNAL_FAILURE_MESSAGE = "Internal Failure";
     public static final int MAX_ERROR_RETRIES = 10;
     public static final int STATE_MACHINE_NAME_MAXLEN = 80;
+    public static final String LOGGING_ACCESS_DENIED_SUBSTRING = "The state machine IAM Role is not authorized to access the Log Destination";
     public static final String MANAGED_RULE_EXCEPTION_MESSAGE_SUBSTRING = "managed-rule";
     public static final String STS_AUTHORIZED_TO_ASSUME_MESSAGE_SUBSTRING =
             "Neither the global service principal states.amazonaws.com, nor the regional one is authorized to assume the provided role";

--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/Constants.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/Constants.java
@@ -10,7 +10,7 @@ public class Constants {
     public static final String INTERNAL_FAILURE_MESSAGE = "Internal Failure";
     public static final int MAX_ERROR_RETRIES = 10;
     public static final int STATE_MACHINE_NAME_MAXLEN = 80;
-    public static final String LOGGING_ACCESS_DENIED_SUBSTRING = "The state machine IAM Role is not authorized to access the Log Destination";
+    public static final String LOGGING_ACCESS_DENIED_MESSAGE_SUBSTRING = "The state machine IAM Role is not authorized to access the Log Destination";
     public static final String MANAGED_RULE_EXCEPTION_MESSAGE_SUBSTRING = "managed-rule";
     public static final String STS_AUTHORIZED_TO_ASSUME_MESSAGE_SUBSTRING =
             "Neither the global service principal states.amazonaws.com, nor the regional one is authorized to assume the provided role";

--- a/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilderTest.java
+++ b/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilderTest.java
@@ -36,6 +36,9 @@ public class ClientBuilderTest {
 
         e.setErrorMessage(Constants.STS_AUTHORIZED_TO_ASSUME_MESSAGE_SUBSTRING);
         assertThat(retryPolicy.getRetryCondition().shouldRetry(request, e, 0)).isTrue();
+
+        e.setErrorMessage(Constants.LOGGING_ACCESS_DENIED_SUBSTRING);
+        assertThat(retryPolicy.getRetryCondition().shouldRetry(request, e, 0)).isTrue();
     }
 
 }

--- a/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilderTest.java
+++ b/statemachine/src/test/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilderTest.java
@@ -37,7 +37,7 @@ public class ClientBuilderTest {
         e.setErrorMessage(Constants.STS_AUTHORIZED_TO_ASSUME_MESSAGE_SUBSTRING);
         assertThat(retryPolicy.getRetryCondition().shouldRetry(request, e, 0)).isTrue();
 
-        e.setErrorMessage(Constants.LOGGING_ACCESS_DENIED_SUBSTRING);
+        e.setErrorMessage(Constants.LOGGING_ACCESS_DENIED_MESSAGE_SUBSTRING);
         assertThat(retryPolicy.getRetryCondition().shouldRetry(request, e, 0)).isTrue();
     }
 


### PR DESCRIPTION
*Description of changes:*
Creation of state machines with logging enabled can fail due to IAM propagation delay. We do not currently retry on these failures, which is causing stack creations to fail. 

This change updates the client's retry policy to retry if the failure is due to missing logging permissions.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
