### PR TITLE
Update DefinitionSubstitutions schema to use anyOf

### DIFF
--- a/statemachine/aws-stepfunctions-statemachine.json
+++ b/statemachine/aws-stepfunctions-statemachine.json
@@ -102,7 +102,7 @@
       "additionalProperties": false,
       "patternProperties": {
         ".*": {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string"
             },


### PR DESCRIPTION
*Issue # (related to an undesired behavior raised in issue):* [#14](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-stepfunctions/issues/14) - [here](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-stepfunctions/issues/14#issuecomment-1416039613)

*Description of changes:*
Replace `DefinitionSubstitutions`' use of `oneOf` to `anyOf` in the schema. This fix removes the false-positive validation error messages that appears for `DefinitionSubstitutions`.

This was tested and validated through the integration tests, which had this validation error (but did not prevent the stacks from being created). After this change, the validation error no longer appears.

The change will not break or affect existing templates since `anyOf` is more permissive than `oneOf`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
