### PR TITLE
Sync activity resource from private repo

### DIFF
--- a/activity/.rpdk-config
+++ b/activity/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::StepFunctions::Activity",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
             "activity"
         ],
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "com.amazonaws.stepfunctions.cloudformation.activity.HandlerWrapperExecutable"
 }

--- a/activity/aws-stepfunctions-activity.json
+++ b/activity/aws-stepfunctions-activity.json
@@ -67,7 +67,8 @@
   "handlers": {
     "create": {
       "permissions": [
-        "states:CreateActivity"
+        "states:CreateActivity",
+        "states:TagResource"
       ]
     },
     "read": {
@@ -85,7 +86,13 @@
     },
     "delete": {
       "permissions": [
+        "states:DescribeActivity",
         "states:DeleteActivity"
+      ]
+    },
+    "list": {
+      "permissions": [
+        "states:ListActivities"
       ]
     }
   }

--- a/activity/contract-tests-artifacts/inputs_1.json
+++ b/activity/contract-tests-artifacts/inputs_1.json
@@ -1,0 +1,23 @@
+{
+  "CreateInputs": {
+    "Name": "ContractTestActivityName-{{uuid}}",
+    "Tags": [
+      {
+        "Key": "Key1",
+        "Value": "Value1"
+      }
+    ]
+  },
+  "PatchInputs": [
+    {
+      "op": "replace",
+      "path": "/Tags/0/Value",
+      "value": "Value2"
+    },
+    {
+      "op": "replace",
+      "path": "/Tags/0/Key",
+      "value": "Key2"
+    }
+  ]
+}

--- a/activity/contract-tests-artifacts/inputs_2.json
+++ b/activity/contract-tests-artifacts/inputs_2.json
@@ -1,0 +1,6 @@
+{
+  "CreateInputs": {
+    "Name": "ThisNameDoesNotExist-{{uuid}}"
+  },
+  "PatchInputs": []
+}

--- a/activity/contract-tests-artifacts/inputs_3.json
+++ b/activity/contract-tests-artifacts/inputs_3.json
@@ -1,0 +1,12 @@
+{
+  "CreateInputs": {
+    "Name": "ContractTestActivityName-{{uuid}}",
+    "Tags": [
+      {
+        "Key": "Key2",
+        "Value": "Value2"
+      }
+    ]
+  },
+  "PatchInputs": []
+}

--- a/activity/docs/README.md
+++ b/activity/docs/README.md
@@ -36,9 +36,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>80</code>
+_Maximum Length_: <code>80</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/activity/docs/tagsentry.md
+++ b/activity/docs/tagsentry.md
@@ -28,9 +28,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -40,8 +40,8 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/activity/inputs/inputs_1_create.json
+++ b/activity/inputs/inputs_1_create.json
@@ -1,9 +1,0 @@
-{
-  "Name": "ContractTestActivityName",
-  "Tags": [
-    {
-      "Key": "Key1",
-      "Value": "Value1"
-    }
-  ]
-}

--- a/activity/inputs/inputs_1_invalid.json
+++ b/activity/inputs/inputs_1_invalid.json
@@ -1,3 +1,0 @@
-{
-  "Name": "ThisNameDoesNotExist"
-}

--- a/activity/inputs/inputs_1_update.json
+++ b/activity/inputs/inputs_1_update.json
@@ -1,9 +1,0 @@
-{
-  "Name": "ContractTestActivityName",
-  "Tags": [
-    {
-      "Key": "Key2",
-      "Value": "Value2"
-    }
-  ]
-}

--- a/activity/pom.xml
+++ b/activity/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.26</version>
             <scope>provided</scope>
         </dependency>
 
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/activity/resource-role.yaml
+++ b/activity/resource-role.yaml
@@ -33,6 +33,7 @@ Resources:
                 - "states:CreateActivity"
                 - "states:DeleteActivity"
                 - "states:DescribeActivity"
+                - "states:ListActivities"
                 - "states:ListTagsForResource"
                 - "states:TagResource"
                 - "states:UntagResource"

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/Constants.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/Constants.java
@@ -1,7 +1,8 @@
 package com.amazonaws.stepfunctions.cloudformation.activity;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
 import java.util.Set;
 
 public class Constants {
@@ -11,9 +12,10 @@ public class Constants {
     public static final String ACTIVITY_ARN_NOT_FOUND_MESSAGE = "ActivityArnNotFound";
     public static final String ACTIVITY_DOES_NOT_EXIST_ERROR_CODE = "ActivityDoesNotExist";
     public static final String RESOURCE_NOT_FOUND_ERROR_CODE = "ResourceNotFound";
+    public static final String INVALID_TOKEN = "InvalidToken";
 
-    public static final Set<String> RESOURCE_NOT_FOUND_ERROR_CODES = Sets.newHashSet(
+    public static final Set<String> RESOURCE_NOT_FOUND_ERROR_CODES = Collections.unmodifiableSet(ImmutableSet.of(
             RESOURCE_NOT_FOUND_ERROR_CODE,
             ACTIVITY_DOES_NOT_EXIST_ERROR_CODE
-    );
+    ));
 }

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/ListHandler.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/ListHandler.java
@@ -1,0 +1,66 @@
+package com.amazonaws.stepfunctions.cloudformation.activity;
+
+import com.amazonaws.services.stepfunctions.AWSStepFunctions;
+import com.amazonaws.services.stepfunctions.model.ActivityListItem;
+import com.amazonaws.services.stepfunctions.model.ListActivitiesRequest;
+import com.amazonaws.services.stepfunctions.model.ListActivitiesResult;
+
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListHandler extends ResourceHandler {
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> resourceHandlerRequest,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+
+        logger.log("INFO Activity ListHandler with clientRequestToken: " + resourceHandlerRequest.getClientRequestToken());
+
+        try {
+            final AWSStepFunctions sfnClient = ClientBuilder.getClient();
+            final List<ResourceModel> models = new ArrayList<>();
+
+            final ListActivitiesRequest listActivitiesRequest = new ListActivitiesRequest();
+            listActivitiesRequest.setNextToken(resourceHandlerRequest.getNextToken());
+
+            final ListActivitiesResult listActivitiesResult = proxy.injectCredentialsAndInvoke(
+                    listActivitiesRequest,
+                    sfnClient::listActivities
+            );
+
+            listActivitiesResult.getActivities()
+                    .stream()
+                    .map(this::buildResourceModelFromActivityListItem)
+                    .forEach(models::add);
+
+            final ProgressEvent<ResourceModel, CallbackContext> progressEvent =
+                    ProgressEvent.<ResourceModel, CallbackContext>builder()
+                            .resourceModels(models)
+                            .nextToken(listActivitiesResult.getNextToken())
+                            .status(OperationStatus.SUCCESS)
+                            .build();
+
+            return progressEvent;
+        } catch (final Exception e) {
+            logger.log("ERROR Listing Activities, caused by " + e.toString());
+
+            return handleDefaultError(resourceHandlerRequest, e);
+        }
+    }
+
+    private ResourceModel buildResourceModelFromActivityListItem(final ActivityListItem activityListItem) {
+        return ResourceModel.builder()
+                .arn(activityListItem.getActivityArn())
+                .name(activityListItem.getName())
+                .build();
+    }
+}

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/ResourceHandler.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/ResourceHandler.java
@@ -34,6 +34,10 @@ public abstract class ResourceHandler extends BaseHandler<CallbackContext> {
                     resultBuilder.errorCode(HandlerErrorCode.NotFound);
                     resultBuilder.message(amznException.getMessage());
                     resultBuilder.status(OperationStatus.FAILED);
+                } else if (Constants.INVALID_TOKEN.equals(errorCode)) {
+                    resultBuilder.errorCode(HandlerErrorCode.InvalidRequest);
+                    resultBuilder.message(amznException.getMessage());
+                    resultBuilder.status(OperationStatus.FAILED);
                 } else {
                     // 400s except for throttle default to FAILURE
                     resultBuilder.errorCode(HandlerErrorCode.GeneralServiceException);

--- a/activity/src/test/java/com/amazonaws/stepfunctions/cloudformation/activity/ListHandlerTest.java
+++ b/activity/src/test/java/com/amazonaws/stepfunctions/cloudformation/activity/ListHandlerTest.java
@@ -1,0 +1,159 @@
+package com.amazonaws.stepfunctions.cloudformation.activity;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.stepfunctions.model.ActivityListItem;
+import com.amazonaws.services.stepfunctions.model.ListActivitiesRequest;
+import com.amazonaws.services.stepfunctions.model.ListActivitiesResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.Function;
+
+import static com.amazonaws.stepfunctions.cloudformation.activity.Constants.ACCESS_DENIED_ERROR_CODE;
+import static com.amazonaws.stepfunctions.cloudformation.activity.Constants.INVALID_TOKEN;
+import static com.amazonaws.stepfunctions.cloudformation.activity.Constants.THROTTLING_ERROR_CODE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class ListHandlerTest extends HandlerTestBase {
+    private ListHandler handler = new ListHandler();
+
+    @Mock
+    private ListActivitiesResult mockListActivitiesResult;
+    @Mock
+    private ActivityListItem mockActivityListItem;
+
+    private final String ACTIVITY_ARN = "arn:aws:states:us-east-1:1234567890:activity:foo";
+    private final String ACTIVITY_NAME = "name";
+    private final String NEXT_TOKEN = "token";
+
+    private ResourceHandlerRequest<ResourceModel> request;
+
+    @BeforeEach
+    public void setup() {
+        request = ResourceHandlerRequest.<ResourceModel>builder()
+                .region(REGION)
+                .awsAccountId(AWS_ACCOUNT_ID)
+                .build();
+    }
+
+    @Test
+    public void testSuccess() {
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .arn(ACTIVITY_ARN)
+                .name(ACTIVITY_NAME)
+                .build();
+
+        when(proxy.injectCredentialsAndInvoke(any(ListActivitiesRequest.class), any(Function.class)))
+                .thenReturn(mockListActivitiesResult);
+
+        when(mockListActivitiesResult.getActivities()).thenReturn(Arrays.asList(mockActivityListItem));
+        when(mockListActivitiesResult.getNextToken()).thenReturn(null);
+        when(mockActivityListItem.getActivityArn()).thenReturn(ACTIVITY_ARN);
+        when(mockActivityListItem.getName()).thenReturn(ACTIVITY_NAME);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getResourceModels()).containsExactly(expectedModel);
+        assertThat(response.getNextToken()).isNull();
+    }
+
+    @Test
+    public void testSuccessReturnsNextToken() {
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .arn(ACTIVITY_ARN)
+                .name(ACTIVITY_NAME)
+                .build();
+
+        when(proxy.injectCredentialsAndInvoke(any(ListActivitiesRequest.class), any(Function.class)))
+                .thenReturn(mockListActivitiesResult);
+
+        when(mockListActivitiesResult.getActivities()).thenReturn(Arrays.asList(mockActivityListItem));
+        when(mockListActivitiesResult.getNextToken()).thenReturn(NEXT_TOKEN);
+
+        when(mockActivityListItem.getActivityArn()).thenReturn(ACTIVITY_ARN);
+        when(mockActivityListItem.getName()).thenReturn(ACTIVITY_NAME);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getResourceModels()).containsExactly(expectedModel);
+        assertThat(response.getNextToken()).isEqualTo(NEXT_TOKEN);
+    }
+
+    @Test
+    public void testSuccessWithEmptyList() {
+        when(mockListActivitiesResult.getActivities()).thenReturn(Collections.emptyList());
+
+        when(proxy.injectCredentialsAndInvoke(any(ListActivitiesRequest.class), any(Function.class)))
+                .thenReturn(mockListActivitiesResult);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getResourceModels()).isEmpty();
+    }
+
+    @Test
+    public void testFailureWithInvalidTokenError() {
+        final AmazonServiceException exceptionInvalidToken = createAndMockAmazonServiceException(INVALID_TOKEN);
+        assertFailure(exceptionInvalidToken.getMessage(), HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void testFailureAccessDeniedError() {
+        final AmazonServiceException exceptionAccessDenied = createAndMockAmazonServiceException(ACCESS_DENIED_ERROR_CODE);
+        assertFailure(exceptionAccessDenied.getMessage(), HandlerErrorCode.AccessDenied);
+    }
+
+    @Test
+    public void testFailureThrottlingError() {
+        final AmazonServiceException exceptionThrottling = createAndMockAmazonServiceException(THROTTLING_ERROR_CODE);
+        assertFailure(exceptionThrottling.getMessage(), HandlerErrorCode.Throttling);
+    }
+
+    @Test
+    public void testFailureWithInternalError() {
+        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(ListActivitiesRequest.class), Mockito.any(Function.class)))
+                .thenThrow(exception500);
+
+        assertFailure(exception500.getMessage(), HandlerErrorCode.ServiceInternalError);
+    }
+
+    private AmazonServiceException createAndMockAmazonServiceException(final String errorCode) {
+        final AmazonServiceException amazonServiceException = new AmazonServiceException(errorCode);
+        amazonServiceException.setStatusCode(400);
+        amazonServiceException.setErrorCode(errorCode);
+
+        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(ListActivitiesRequest.class), Mockito.any(Function.class)))
+                .thenThrow(amazonServiceException);
+
+        return amazonServiceException;
+    }
+
+    private void assertFailure(final String message, final HandlerErrorCode code) {
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getMessage()).isEqualTo(message);
+        assertThat(response.getErrorCode()).isEqualTo(code);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Syncing the changes from our private repository for activity resource. Goal here is to bring our public repo on Github up to speed so that all changes to the handler code will from now on go through our repo.

Changes include:
* Adding ListHandler
* Upgrade to Contract Test V2

Ran `pre-commit` on the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
