### PR TITLE
Upgrade Lambda runtimes from java8 to java8.al2

### DIFF
--- a/activity/.rpdk-config
+++ b/activity/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::StepFunctions::Activity",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java8.al2",
     "entrypoint": "com.amazonaws.stepfunctions.cloudformation.activity.HandlerWrapper::handleRequest",
     "testEntrypoint": "com.amazonaws.stepfunctions.cloudformation.activity.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/activity/template.yml
+++ b/activity/template.yml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       Handler: com.amazonaws.stepfunctions.cloudformation.activity.HandlerWrapper::handleRequest
       MemorySize: 256
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-stepfunctions-activity-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
@@ -20,5 +20,5 @@ Resources:
     Properties:
       Handler: com.amazonaws.stepfunctions.cloudformation.activity.HandlerWrapper::testEntrypoint
       MemorySize: 256
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-stepfunctions-activity-handler-1.0-SNAPSHOT.jar

--- a/statemachine/.rpdk-config
+++ b/statemachine/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::StepFunctions::StateMachine",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java8.al2",
     "entrypoint": "com.amazonaws.stepfunctions.cloudformation.statemachine.HandlerWrapper::handleRequest",
     "testEntrypoint": "com.amazonaws.stepfunctions.cloudformation.statemachine.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/statemachine/template.yml
+++ b/statemachine/template.yml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       Handler: com.amazonaws.stepfunctions.cloudformation.statemachine.HandlerWrapper::handleRequest
       MemorySize: 256
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-stepfunctions-statemachine-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
@@ -20,5 +20,5 @@ Resources:
     Properties:
       Handler: com.amazonaws.stepfunctions.cloudformation.statemachine.HandlerWrapper::testEntrypoint
       MemorySize: 256
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-stepfunctions-statemachine-handler-1.0-SNAPSHOT.jar

--- a/statemachinealias/.rpdk-config
+++ b/statemachinealias/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::StepFunctions::StateMachineAlias",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java8.al2",
     "entrypoint": "com.amazonaws.stepfunctions.cloudformation.statemachinealias.HandlerWrapper::handleRequest",
     "testEntrypoint": "com.amazonaws.stepfunctions.cloudformation.statemachinealias.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/statemachinealias/template.yml
+++ b/statemachinealias/template.yml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       Handler: com.amazonaws.stepfunctions.cloudformation.statemachinealias.HandlerWrapper::handleRequest
       MemorySize: 256
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-stepfunctions-statemachinealias-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
@@ -20,5 +20,5 @@ Resources:
     Properties:
       Handler: com.amazonaws.stepfunctions.cloudformation.statemachinealias.HandlerWrapper::testEntrypoint
       MemorySize: 256
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-stepfunctions-statemachinealias-handler-1.0-SNAPSHOT.jar

--- a/statemachineversion/.rpdk-config
+++ b/statemachineversion/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::StepFunctions::StateMachineVersion",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java8.al2",
     "entrypoint": "com.amazonaws.stepfunctions.cloudformation.statemachineversion.HandlerWrapper::handleRequest",
     "testEntrypoint": "com.amazonaws.stepfunctions.cloudformation.statemachineversion.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/statemachineversion/template.yml
+++ b/statemachineversion/template.yml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       Handler: com.amazonaws.stepfunctions.cloudformation.statemachineversion.HandlerWrapper::handleRequest
       MemorySize: 256
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-stepfunctions-statemachineversion-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
@@ -20,5 +20,5 @@ Resources:
     Properties:
       Handler: com.amazonaws.stepfunctions.cloudformation.statemachineversion.HandlerWrapper::testEntrypoint
       MemorySize: 256
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-stepfunctions-statemachineversion-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Bump runtime `java8` -> `java8.al2`

Upgrading Lambda runtime in `.rpdk-config` and `template.yml` files for all resources, since we are nearing the Deprecation date for `java8`.

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
