### PR TITLE
Enable ForceGlobalBucketAccess on S3 client

### DIFF
--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilder.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/ClientBuilder.java
@@ -14,7 +14,9 @@ import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder;
 public class ClientBuilder {
 
     public static AmazonS3 getS3Client() {
-        return AmazonS3ClientBuilder.standard().build();
+        return AmazonS3ClientBuilder.standard()
+                .withForceGlobalBucketAccessEnabled(true)
+                .build();
     }
 
     public static AWSStepFunctions getClient() {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Add `.withForceGlobalBucketAccessEnabled(true)` to the S3 client builder.

This will enable cross-region access to S3 buckets. While S3 bucket names are globally unique, the data within each bucket is stored in a specific region chosen by the user, and the StateMachine resource handler cannot handler the scenario where the S3 bucket location is different from the region where the Create Handler is invoked.

Currently, if the region where the bucket is physically located differs from the client config in [AwsClientBuilder.setRegion(String)](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/client/builder/AwsClientBuilder.html#setRegion-java.lang.String-), then the `GetObject` call to S3 fails and the Create handler is unable to retrieve the definition from the S3 bucket, resulting in `CREATE_FAILED`

When enabled, the region of the bucket can differ from the client config and still succeed, since the client will determine the correct region to route the request.

>The following behavior is currently used when this mode is enabled:
>
> 1. All requests that do not act on an existing bucket (for example, [AmazonS3Client.createBucket(String)](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#createBucket-java.lang.String-)) will be routed to the region configured by [AwsClientBuilder.setRegion(String)](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/client/builder/AwsClientBuilder.html#setRegion-java.lang.String-), unless the region is manually overridden with [CreateBucketRequest.setRegion(String)](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/CreateBucketRequest.html#setRegion-java.lang.String-), in which case the request will be routed to the region configured in the request.
> 2. The first time a request is made that references an existing bucket (for example, [AmazonS3Client.putObject(PutObjectRequest)](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#putObject-com.amazonaws.services.s3.model.PutObjectRequest-)) a request will be made to the region configured by [AwsClientBuilder.setRegion(String)](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/client/builder/AwsClientBuilder.html#setRegion-java.lang.String-) to determine the region in which the bucket was created. This location may be cached in the client for subsequent requests acting on that same bucket.
Enabling this mode has several drawbacks, because it has the potential to increase latency in the event that the location of the bucket is physically far from the location from which the request was invoked. For this reason, it is strongly advised when possible to know the location of your buckets and create a region-specific client to access that bucket.

https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#setForceGlobalBucketAccessEnabled-java.lang.Boolean-

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
