### PR TITLE
Add static stabilization to Activity Delete handler

### DIFF
--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/CallbackContext.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/CallbackContext.java
@@ -1,12 +1,18 @@
 package com.amazonaws.stepfunctions.cloudformation.activity;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.NoArgsConstructor;
+import software.amazon.cloudformation.proxy.StdCallbackContext;
 
-@Data
-@NoArgsConstructor
 @Builder
-public class CallbackContext {
-
+@AllArgsConstructor
+@NoArgsConstructor
+@lombok.Getter
+@lombok.Setter
+@lombok.ToString
+@lombok.EqualsAndHashCode(callSuper = true)
+public class CallbackContext extends StdCallbackContext {
+    @Builder.Default
+    private boolean propagationDelayDone = false;
 }

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/Constants.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/Constants.java
@@ -18,4 +18,7 @@ public class Constants {
             RESOURCE_NOT_FOUND_ERROR_CODE,
             ACTIVITY_DOES_NOT_EXIST_ERROR_CODE
     ));
+
+    // Setting 60 seconds stabilization delay to account for eventual consistency of DescribeActivity call
+    public static final int CALLBACK_DELAY_SECONDS_FOR_STABILIZATION = 60;
 }

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandler.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandler.java
@@ -9,18 +9,28 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static com.amazonaws.stepfunctions.cloudformation.activity.Constants.CALLBACK_DELAY_SECONDS_FOR_STABILIZATION;
+
 public class DeleteHandler extends ResourceHandler {
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-        final AmazonWebServicesClientProxy proxy,
-        final ResourceHandlerRequest<ResourceModel> request,
-        final CallbackContext callbackContext,
-        final Logger logger) {
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
 
         logger.log("INFO Activity DeleteHandler with clientRequestToken: " + request.getClientRequestToken());
 
         final ResourceModel model = request.getDesiredResourceState();
+
+        final CallbackContext context = (callbackContext == null) ? new CallbackContext() : callbackContext;
+
+        if (context.isPropagationDelayDone()) {
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .status(OperationStatus.SUCCESS)
+                    .build();
+        }
 
         try {
             verifyActivityArnIsPresent(model.getArn());
@@ -37,9 +47,8 @@ public class DeleteHandler extends ResourceHandler {
 
             proxy.injectCredentialsAndInvoke(deleteActivityRequest, sfnClient::deleteActivity);
 
-            return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                    .status(OperationStatus.SUCCESS)
-                    .build();
+            context.setPropagationDelayDone(true);
+            return ProgressEvent.defaultInProgressHandler(context, CALLBACK_DELAY_SECONDS_FOR_STABILIZATION, model);
         } catch (Exception e) {
             logger.log("ERROR Deleting Activity, caused by " + e.toString());
             return handleDefaultError(request, e);

--- a/activity/src/test/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandlerTest.java
+++ b/activity/src/test/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandlerTest.java
@@ -38,20 +38,29 @@ public class DeleteHandlerTest extends HandlerTestBase {
     }
 
     @Test
-    public void testSuccess() {
-        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class))).thenReturn(new DescribeActivityResult());
+    public void testDeleteHandler_pausesFor60sToStabilize_returnsSuccess() {
+        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class)))
+                .thenReturn(new DescribeActivityResult());
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-            = handler.handleRequest(proxy, request, null, logger);
+                = handler.handleRequest(proxy, request, null, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isNull();
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isNotNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(60);
+
+        final ProgressEvent<ResourceModel, CallbackContext> responseFromCallback
+                = handler.handleRequest(proxy, request, response.getCallbackContext(), logger);
+
+        assertThat(responseFromCallback).isNotNull();
+        assertThat(responseFromCallback.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(responseFromCallback.getCallbackContext()).isNull();
+        assertThat(responseFromCallback.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(responseFromCallback.getResourceModel()).isNull();
+        assertThat(responseFromCallback.getResourceModels()).isNull();
+        assertThat(responseFromCallback.getMessage()).isNull();
+        assertThat(responseFromCallback.getErrorCode()).isNull();
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Add static stabilization to `AWS::StepFunctions::Activity` resource's Delete handler

`DescribeActivity` operation is eventually consistent. The results are best effort and may not reflect very recent updates and changes. This results in the Read handler not always retrieving the correct state after the deletion of an activity. (e.g. Invoke Delete handler, and the immediately invoking Read handler may return the activity details despite the activity having been deleted)

This change follows CloudFormation's best practices in how to develop resource handlers:

> DO NOT delegate the response of the model, check existence, or stabilization in CREATE, UPDATE and DELETE handler to the READ handler

This change adds the following logic to stabilize the deletion:

* Pause Delete handler for 60 seconds and then return `SUCCESS` (static stabilization)

*Testing*:

`mvn test` succeeds, and ran `pre-commit run --all-files`

Ran contract tests locally and all runs have succeeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
