### PR TITLE
Fix Activity callback context spotbug issue

### DIFF
--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/CallbackContext.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/CallbackContext.java
@@ -3,9 +3,11 @@ package com.amazonaws.stepfunctions.cloudformation.activity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Fix spotBug issue identified in CallbackContext class for Activity resource

> #### EQ_OVERRIDING_EQUALS_NOT_SYMMETRIC: equals method overrides equals in superclass and may not be symmetric
> 
> This class defines an equals method that overrides an equals method in a superclass. Both equals methods methods use instanceof in the determination of whether two objects are equal. This is fraught with peril, since it is important that the equals method is symmetrical (in other words, a.equals(b) == b.equals(a)). If B is a subtype of A, and A's equals method checks that the argument is an instanceof A, and B's equals method checks that the argument is an instanceof B, it is quite likely that the equivalence relation defined by these methods is not symmetric.

Culprit is that the super class implements both equals and hashCode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
