### PR TITLE
Add static stabilization to Activity Delete handler

### DIFF
--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/CallbackContext.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/CallbackContext.java
@@ -1,12 +1,18 @@
 package com.amazonaws.stepfunctions.cloudformation.activity;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import software.amazon.cloudformation.proxy.StdCallbackContext;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 @Builder
-public class CallbackContext {
-
+public class CallbackContext extends StdCallbackContext {
+    @Builder.Default
+    private boolean propagationDelayDone = false;
 }

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/CallbackContext.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/CallbackContext.java
@@ -1,16 +1,12 @@
 package com.amazonaws.stepfunctions.cloudformation.activity;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import software.amazon.cloudformation.proxy.StdCallbackContext;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @Builder
-public class CallbackContext extends StdCallbackContext {
-    private boolean isActivityDeletionStarted;
-    private int retryCount;
+public class CallbackContext {
+
 }

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/Constants.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/Constants.java
@@ -18,4 +18,7 @@ public class Constants {
             RESOURCE_NOT_FOUND_ERROR_CODE,
             ACTIVITY_DOES_NOT_EXIST_ERROR_CODE
     ));
+
+    // Setting 60 seconds stabilization delay to account for eventual consistency of DescribeActivity call due to caching
+    public static final int CALLBACK_DELAY_SECONDS_FOR_STABILIZATION = 60;
 }

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandler.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandler.java
@@ -9,18 +9,28 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static com.amazonaws.stepfunctions.cloudformation.activity.Constants.CALLBACK_DELAY_SECONDS_FOR_STABILIZATION;
+
 public class DeleteHandler extends ResourceHandler {
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-        final AmazonWebServicesClientProxy proxy,
-        final ResourceHandlerRequest<ResourceModel> request,
-        final CallbackContext callbackContext,
-        final Logger logger) {
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
 
         logger.log("INFO Activity DeleteHandler with clientRequestToken: " + request.getClientRequestToken());
 
         final ResourceModel model = request.getDesiredResourceState();
+
+        final CallbackContext context = (callbackContext == null) ? new CallbackContext() : callbackContext;
+
+        if (context.isPropagationDelayDone()) {
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .status(OperationStatus.SUCCESS)
+                    .build();
+        }
 
         try {
             verifyActivityArnIsPresent(model.getArn());
@@ -37,9 +47,8 @@ public class DeleteHandler extends ResourceHandler {
 
             proxy.injectCredentialsAndInvoke(deleteActivityRequest, sfnClient::deleteActivity);
 
-            return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                    .status(OperationStatus.SUCCESS)
-                    .build();
+            context.setPropagationDelayDone(true);
+            return ProgressEvent.defaultInProgressHandler(context, CALLBACK_DELAY_SECONDS_FOR_STABILIZATION, model);
         } catch (Exception e) {
             logger.log("ERROR Deleting Activity, caused by " + e.toString());
             return handleDefaultError(request, e);

--- a/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandler.java
+++ b/activity/src/main/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandler.java
@@ -1,136 +1,49 @@
 package com.amazonaws.stepfunctions.cloudformation.activity;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.services.stepfunctions.AWSStepFunctions;
-import com.amazonaws.services.stepfunctions.AWSStepFunctionsClientBuilder;
 import com.amazonaws.services.stepfunctions.model.DeleteActivityRequest;
 import com.amazonaws.services.stepfunctions.model.DescribeActivityRequest;
-import com.google.common.util.concurrent.Uninterruptibles;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-
 public class DeleteHandler extends ResourceHandler {
-
-    private static final int RETRY_COUNTER = 3;
-    private static final int INITIAL_RETRY_DELAY_SECONDS = 10;
-    private static final int MAX_RETRY_DELAY_SECONDS = 30;
-    private static final int STABILIZATION_CALL_COUNT = 10;
-    private static final Random random = new Random();
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-            final AmazonWebServicesClientProxy proxy,
-            final ResourceHandlerRequest<ResourceModel> request,
-            final CallbackContext callbackContext,
-            final Logger logger) {
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final Logger logger) {
 
         logger.log("INFO Activity DeleteHandler with clientRequestToken: " + request.getClientRequestToken());
 
         final ResourceModel model = request.getDesiredResourceState();
 
         try {
-            if (callbackContext == null || !callbackContext.isActivityDeletionStarted()) {
-                return initiateDeleteActivity(proxy, model, logger);
-            } else {
-                int currentRetryCount = callbackContext.getRetryCount();
-                if (currentRetryCount <= RETRY_COUNTER) {
-                    callbackContext.setRetryCount(currentRetryCount + 1);
-                    return stabilizeDeleteActivity(proxy, model, currentRetryCount + 1, logger);
-                } else {
-                    // Failsafe
-                    // If somehow DescribeActivity is still able to describe the deleted activity after 3 retry
-                    // attempts (>60s since delete), fallback to previous behaviour to not break backwards compatibility.
-                    return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                            .status(OperationStatus.SUCCESS)
-                            .build();
-                }
-            }
+            verifyActivityArnIsPresent(model.getArn());
+
+            AWSStepFunctions sfnClient = ClientBuilder.getClient();
+
+            // Validate that the activity exists
+            DescribeActivityRequest describeActivityRequest = new DescribeActivityRequest();
+            describeActivityRequest.setActivityArn(model.getArn());
+            proxy.injectCredentialsAndInvoke(describeActivityRequest, sfnClient::describeActivity);
+
+            DeleteActivityRequest deleteActivityRequest = new DeleteActivityRequest();
+            deleteActivityRequest.setActivityArn(model.getArn());
+
+            proxy.injectCredentialsAndInvoke(deleteActivityRequest, sfnClient::deleteActivity);
+
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .status(OperationStatus.SUCCESS)
+                    .build();
         } catch (Exception e) {
-            logger.log("ERROR Deleting Activity, caused by " + e);
-            ProgressEvent<ResourceModel, CallbackContext> failedProgressEvent = handleDefaultError(request, e);
-            failedProgressEvent.setCallbackContext(CallbackContext.builder().build());
-
-            return failedProgressEvent;
+            logger.log("ERROR Deleting Activity, caused by " + e.toString());
+            return handleDefaultError(request, e);
         }
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> initiateDeleteActivity(
-            final AmazonWebServicesClientProxy proxy,
-            final ResourceModel model,
-            final Logger logger) {
-        verifyActivityArnIsPresent(model.getArn());
-
-        AWSStepFunctions sfnClient = ClientBuilder.getClient();
-
-        // Validate that the activity exists
-        DescribeActivityRequest describeActivityRequest = new DescribeActivityRequest();
-        describeActivityRequest.setActivityArn(model.getArn());
-        proxy.injectCredentialsAndInvoke(describeActivityRequest, sfnClient::describeActivity);
-
-        DeleteActivityRequest deleteActivityRequest = new DeleteActivityRequest();
-        deleteActivityRequest.setActivityArn(model.getArn());
-
-        proxy.injectCredentialsAndInvoke(deleteActivityRequest, sfnClient::deleteActivity);
-
-        return stabilizeDeleteActivity(proxy, model, 0, logger);
-    }
-
-    private ProgressEvent<ResourceModel, CallbackContext> stabilizeDeleteActivity(
-            final AmazonWebServicesClientProxy proxy,
-            final ResourceModel model,
-            final int currentRetryCount,
-            final Logger logger) {
-
-        ClientConfiguration clientConfiguration = new ClientConfiguration()
-                .withRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY);
-
-        DescribeActivityRequest describeActivityRequest = new DescribeActivityRequest();
-        describeActivityRequest.setActivityArn(model.getArn());
-
-        for (int i = 0; i < STABILIZATION_CALL_COUNT; i++) {
-            try {
-                AWSStepFunctions sfnClient = AWSStepFunctionsClientBuilder.standard()
-                        .withClientConfiguration(clientConfiguration)
-                        .build();
-
-                proxy.injectCredentialsAndInvoke(describeActivityRequest, sfnClient::describeActivity);
-                // If DescribeActivity succeeds, the activity still exists.
-                logger.log("Activity still exists after DescribeActivity attempt #" + (i + 1));
-                // If any DescribeActivity call succeeded, the activity still exists and the cache has not been cleared yet
-                // Retry as DescribeActivity failure count has not reached the desired stabilization attempts
-                return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                        .status(OperationStatus.IN_PROGRESS)
-                        .callbackContext(CallbackContext.builder()
-                                .retryCount(currentRetryCount)
-                                .isActivityDeletionStarted(true)
-                                .build())
-                        .callbackDelaySeconds(calculateExponentialBackoffDelayWithJitter(currentRetryCount))
-                        .build();
-            } catch (Exception e) {
-                // If DescribeActivity fails, wait for the next attempt.
-                logger.log("DescribeActivity failed on attempt #" + (i + 1) + ": " + e.getMessage());
-                Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
-            }
-        }
-
-        // If all DescribeActivity attempts failed, assume the activity is deleted.
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                .status(OperationStatus.SUCCESS)
-                .callbackContext(CallbackContext.builder().build())
-                .build();
-    }
-
-    private int calculateExponentialBackoffDelayWithJitter(int retryAttempt) {
-        int exponentialDelay = Math.min((int) Math.pow(2, retryAttempt) * INITIAL_RETRY_DELAY_SECONDS, MAX_RETRY_DELAY_SECONDS);
-        int jitter = (int) ((random.nextDouble() - 0.5) * exponentialDelay);
-        int delayWithJitter = exponentialDelay + jitter;
-        return Math.min(delayWithJitter, MAX_RETRY_DELAY_SECONDS);
-    }
 }

--- a/activity/src/test/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandlerTest.java
+++ b/activity/src/test/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandlerTest.java
@@ -38,20 +38,29 @@ public class DeleteHandlerTest extends HandlerTestBase {
     }
 
     @Test
-    public void testSuccess() {
-        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class))).thenReturn(new DescribeActivityResult());
+    public void testDeleteHandler_pausesFor60sToStabilize_returnsSuccess() {
+        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class)))
+                .thenReturn(new DescribeActivityResult());
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-            = handler.handleRequest(proxy, request, null, logger);
+                = handler.handleRequest(proxy, request, null, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isNull();
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isNotNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(60);
+
+        final ProgressEvent<ResourceModel, CallbackContext> responseFromCallback
+                = handler.handleRequest(proxy, request, response.getCallbackContext(), logger);
+
+        assertThat(responseFromCallback).isNotNull();
+        assertThat(responseFromCallback.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(responseFromCallback.getCallbackContext()).isNull();
+        assertThat(responseFromCallback.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(responseFromCallback.getResourceModel()).isNull();
+        assertThat(responseFromCallback.getResourceModels()).isNull();
+        assertThat(responseFromCallback.getMessage()).isNull();
+        assertThat(responseFromCallback.getErrorCode()).isNull();
     }
 
     @Test

--- a/activity/src/test/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandlerTest.java
+++ b/activity/src/test/java/com/amazonaws/stepfunctions/cloudformation/activity/DeleteHandlerTest.java
@@ -1,6 +1,6 @@
 package com.amazonaws.stepfunctions.cloudformation.activity;
 
-import com.amazonaws.services.stepfunctions.model.ActivityDoesNotExistException;
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.stepfunctions.model.DescribeActivityRequest;
 import com.amazonaws.services.stepfunctions.model.DescribeActivityResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,87 +38,20 @@ public class DeleteHandlerTest extends HandlerTestBase {
     }
 
     @Test
-    public void testDeleteHandler_describeActivityThrowsErrorAfterDeletion_returnsSuccess() {
-        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class)))
-                .thenReturn(new DescribeActivityResult())
-                .thenThrow(ActivityDoesNotExistException.class);    // Describe call after deletion
+    public void testSuccess() {
+        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class))).thenReturn(new DescribeActivityResult());
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, null, logger);
+            = handler.handleRequest(proxy, request, null, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNotNull();
+        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-    }
-
-    @Test
-    public void testDeleteHandler_describeActivityReturnsActivityDetailsAfterDeletion_returnsInProgress() {
-        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class)))
-                .thenReturn(new DescribeActivityResult())
-                .thenReturn(new DescribeActivityResult());  // Describe call after deletion
-
-        final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, null, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
-        assertThat(response.getCallbackContext()).isNotNull();
-        assertThat(response.getCallbackDelaySeconds()).isNotEqualTo(0);
-    }
-
-    @Test
-    public void testDeleteHandler_callbackWithCallbackContext_describeActivityReturnsActivityDetails_returnsInProgress() {
-        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class)))
-                .thenReturn(new DescribeActivityResult());
-
-        final CallbackContext callbackContext = CallbackContext.builder()
-                .isActivityDeletionStarted(true)
-                .retryCount(1)
-                .build();
-
-        final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, callbackContext, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
-        assertThat(response.getCallbackContext()).isNotNull();
-        assertThat(response.getCallbackDelaySeconds()).isNotEqualTo(0);
-    }
-
-    @Test
-    public void testDeleteHandler_callbackWithCallbackContext_retriesAreExhausted_returnsSuccess_failSafeToPreserveBackwardsCompatibility() {
-        final CallbackContext callbackContext = CallbackContext.builder()
-                .isActivityDeletionStarted(true)
-                .retryCount(4)
-                .build();
-
-        final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, callbackContext, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-    }
-
-    @Test
-    public void testDeleteHandler_callbackWithCallbackContext_describeActivityThrowsError_returnsSuccess() {
-        Mockito.when(proxy.injectCredentialsAndInvoke(Mockito.any(DescribeActivityRequest.class), Mockito.any(Function.class)))
-                .thenThrow(ActivityDoesNotExistException.class);
-
-        final CallbackContext callbackContext = CallbackContext.builder()
-                .isActivityDeletionStarted(true)
-                .retryCount(1)
-                .build();
-
-        final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, callbackContext, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Remove dynamic stabilization (revert) and subsequently

Add static stabilization to `AWS::StepFunctions::Activity` resource's Delete handler

`DescribeActivity` operation is eventually consistent. The results are best effort and may not reflect very recent updates and changes. This results in the Read handler not always retrieving the correct state after the deletion of an activity. (e.g. Invoke Delete handler, and the immediately invoking Read handler may return the activity details despite the activity having been deleted)

This change makes it so that our resource strictly adheres to CloudFormation's [resource type handler contract](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html):

> A read handler MUST return FAILED with a NotFound error code if the resource doesn't exist.

> A delete handler MUST return FAILED with a NotFound error code if the resource didn't exist before the delete request.

This change adds the following logic to stabilize the deletion:

* Pause Delete handler for 60 seconds and then return `SUCCESS` (static stabilization)

*Testing*:

`mvn test` succeeds, and ran `pre-commit run --all-files`

Ran contract tests locally and all runs have succeeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
