### PR TITLE
Update StateMachineAlias schema to set timeoutInMinutes for update handler

### DIFF
--- a/statemachinealias/aws-stepfunctions-statemachinealias.json
+++ b/statemachinealias/aws-stepfunctions-statemachinealias.json
@@ -158,7 +158,8 @@
         "cloudwatch:DescribeAlarms",
         "states:UpdateStateMachineAlias",
         "states:DescribeStateMachineAlias"
-      ]
+      ],
+      "timeoutInMinutes": 2160
     },
     "delete": {
       "permissions": [

--- a/statemachinealias/resource-role.yaml
+++ b/statemachinealias/resource-role.yaml
@@ -7,7 +7,7 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      MaxSessionDuration: 8400
+      MaxSessionDuration: 43200
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Add `timeoutInMinutes` to update handler in the resource schema.

The value is an integer specifying the timeout for the entire operation to be interpreted by the invoker of the handler, in minutes.

When this is not set, the default value of 2h is used and any gradual deployment taking 2h or longer would fail the stack update due to the resource timing out.

`Resource timed out waiting for completion`

By setting the value to 2160 (maximum value), a gradual deployment can take up to 36h to stabilize and the StateMachineAlias resource should not timeout.

*Testing:*
Ran `mvn test` and `pre-commit run --all-files`

Local run of contract tests passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
