### PR TITLE
Pin aws-cloudformation-rpdk-java-plugin to 2.0.16 temporarily

### DIFF
--- a/activity/pom.xml
+++ b/activity/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>2.0.16</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/statemachine/pom.xml
+++ b/statemachine/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>2.0.16</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/statemachinealias/pom.xml
+++ b/statemachinealias/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>2.0.16</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/statemachineversion/pom.xml
+++ b/statemachineversion/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>2.0.16</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Pin aws-cloudformation-rpdk-java-plugin to 2.0.16 temporarily, since the latest version, 2.1.1 is failing to build due to an upgrade from java8 to java17.

We'll upgrade to java17 in the near future and will revert this once we make the upgrade, but we currently need to successfully build to unblock development.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
