### PR TITLE
Inherit StdCallbackContext for CallbackContext

### DIFF
--- a/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CallbackContext.java
+++ b/statemachine/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachine/CallbackContext.java
@@ -4,12 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import software.amazon.cloudformation.proxy.StdCallbackContext;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CallbackContext {
+public class CallbackContext extends StdCallbackContext {
     @Builder.Default
     private boolean deletionStarted = false;
 }

--- a/statemachinealias/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachinealias/CallbackContext.java
+++ b/statemachinealias/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachinealias/CallbackContext.java
@@ -3,6 +3,7 @@ package com.amazonaws.stepfunctions.cloudformation.statemachinealias;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
+
 import java.time.Instant;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;

--- a/statemachineversion/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachineversion/CallbackContext.java
+++ b/statemachineversion/src/main/java/com/amazonaws/stepfunctions/cloudformation/statemachineversion/CallbackContext.java
@@ -4,12 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import software.amazon.cloudformation.proxy.StdCallbackContext;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CallbackContext {
-	@Builder.Default
-	private boolean deletionStarted = false;
+public class CallbackContext extends StdCallbackContext {
+    @Builder.Default
+    private boolean deletionStarted = false;
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Add inheritance for `CallbackContext` objects such that all resources' `CallbackContext` inherit from `StdCallbackContext` ([source](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/proxy/StdCallbackContext.java)).

This enables improved logging for handlers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
